### PR TITLE
Added generation field to Schema to allow dynamic updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ provider "sendgrid" {
 
 resource "sendgrid_template" "first_template" {
   name = "name"
+  generation = "dynamic"
 }
 
 resource "sendgrid_template_version" "first_template_version" {
@@ -102,12 +103,14 @@ provider "sendgrid" {
 ```ruby
 resource "sendgrid_template" "my_template" {
   name = "my_template"
+  generation = "legacy"
 }
 ```
 
 #### Parameters
 
 * `name`: Required. The name of the template.
+* `generation`: Optional. Defines whether the template supports dynamic replacement. [`dynamic`|`legacy`]
 
 #### Exported Parameters
 

--- a/sendgrid/provider.go
+++ b/sendgrid/provider.go
@@ -12,9 +12,9 @@ import (
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			"api_key": &schema.Schema{
+			"api_key": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SENDGRID_API_KEY", nil),
 			},
 		},

--- a/sendgrid/resource_sendgrid_template.go
+++ b/sendgrid/resource_sendgrid_template.go
@@ -24,6 +24,10 @@ func resourceSendgridTemplate() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"generation": &schema.Schema{
+                Type:     schema.TypeString,
+                Optional: true,
+            },
 		},
 	}
 }
@@ -31,6 +35,7 @@ func resourceSendgridTemplate() *schema.Resource {
 func buildTemplateStruct(d *schema.ResourceData) *sendgrid_client.Template {
 	m := sendgrid_client.Template{
 		Name: d.Get("name").(string),
+		Generation: d.Get("generation").(string),
 	}
 
 	return &m
@@ -76,7 +81,7 @@ func resourceSendgridTemplateRead(d *schema.ResourceData, meta interface{}) erro
 	if err != nil {
 		return fmt.Errorf("error reading template: %s", err.Error())
 	}
-	fmt.Println("[DEBUG] Template: %v", m)
+	fmt.Printf("[DEBUG] Template: %v", m)
 	d.Set("name", m.Name)
 
 	return nil

--- a/sendgrid/resource_sendgrid_template_test.go
+++ b/sendgrid/resource_sendgrid_template_test.go
@@ -22,6 +22,8 @@ func TestAccSendgridTemplate_Basic(t *testing.T) {
 					testAccCheckSendgridTemplateExists("sendgrid_template.foo"),
 					resource.TestCheckResourceAttr(
 						"sendgrid_template.foo", "name", "name for template foo"),
+					resource.TestCheckResourceAttr(
+						"sendgrid_template.foo", "generation", "dynamic"),
 				),
 			},
 		},
@@ -40,6 +42,8 @@ func TestAccSendgridTemplate_Updated(t *testing.T) {
 					testAccCheckSendgridTemplateExists("sendgrid_template.foo"),
 					resource.TestCheckResourceAttr(
 						"sendgrid_template.foo", "name", "name for template foo"),
+					resource.TestCheckResourceAttr(
+						"sendgrid_template.foo", "generation", "dynamic"),
 				),
 			},
 			resource.TestStep{
@@ -48,6 +52,8 @@ func TestAccSendgridTemplate_Updated(t *testing.T) {
 					testAccCheckSendgridTemplateExists("sendgrid_template.foo"),
 					resource.TestCheckResourceAttr(
 						"sendgrid_template.foo", "name", "name for template bar"),
+					resource.TestCheckResourceAttr(
+						"sendgrid_template.foo", "generation", "legacy"),
 				),
 			},
 		},
@@ -78,12 +84,14 @@ func testAccCheckSendgridTemplateExists(n string) resource.TestCheckFunc {
 const testAccCheckSendgridTemplateConfig = `
 resource "sendgrid_template" "foo" {
   name = "name for template foo"
+  generation = "dynamic"
 }
 `
 
 const testAccCheckSendgridTemplateConfigUpdated = `
 resource "sendgrid_template" "foo" {
   name = "name for template bar"
+  generation = "legacy"
 }
 `
 

--- a/sendgrid/resource_sendgrid_template_version.go
+++ b/sendgrid/resource_sendgrid_template_version.go
@@ -195,12 +195,12 @@ func resourceSendgridTemplateVersionImport(d *schema.ResourceData, meta interfac
 func loadFileContent(v string) ([]byte, error) {
 	filename, err := homedir.Expand(v)
 	if err != nil {
-		fmt.Println("File %s can't be expand. %s", v, err)
+		fmt.Printf("File %s can't be expand. %s", v, err)
 		return nil, err
 	}
 	fileContent, err := ioutil.ReadFile(filename)
 	if err != nil {
-		fmt.Println("File %s can't be read. %s", filename, err)
+		fmt.Printf("File %s can't be read. %s", filename, err)
 		return nil, err
 	}
 	return fileContent, nil

--- a/sendgrid/resource_sendgrid_template_version_test.go
+++ b/sendgrid/resource_sendgrid_template_version_test.go
@@ -192,12 +192,12 @@ func TestAccSendgridTemplateVersion_UpdatedContent(t *testing.T) {
 func writeContent(file string, content string) error {
 	filename, err := homedir.Expand(file)
 	if err != nil {
-		fmt.Println("File %s can't be expand. %s", file, err)
+		fmt.Printf("File %s can't be expand. %s", file, err)
 		return err
 	}
 	err = ioutil.WriteFile(filename, []byte(content), 0644)
 	if err != nil {
-		fmt.Println("File %s can't be written. %s", filename, err)
+		fmt.Printf("File %s can't be written. %s", filename, err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
### Description of Changes

- Added ```generation``` field to sendgrid/resource_sendgrid_template.go
- Changed ```api_key``` to Optional because it errors when running Acceptance tests when its set as Required
- Changed the Println to Printf for any Strings that are being substituted.

### Description of new field
This field allows using the newer dynamic templates. 
Here is the API information about the field:
https://dynamic-templates.api-docs.io/3.0/templates/create-a-transactional-template