### PR TITLE
Fixed main.go to import qstream provider

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/opteemister/terraform-provider-sendgrid/sendgrid"
+	"github.com/qstream/terraform-provider-sendgrid/sendgrid"
 )
 
 func main() {

--- a/sendgrid/provider.go
+++ b/sendgrid/provider.go
@@ -14,7 +14,7 @@ func Provider() terraform.ResourceProvider {
 		Schema: map[string]*schema.Schema{
 			"api_key": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SENDGRID_API_KEY", nil),
 			},
 		},

--- a/sendgrid/resource_sendgrid_template.go
+++ b/sendgrid/resource_sendgrid_template.go
@@ -20,14 +20,14 @@ func resourceSendgridTemplate() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"generation": &schema.Schema{
-                Type:     schema.TypeString,
-                Optional: true,
-            },
+			"generation": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }


### PR DESCRIPTION
This PR changes the import of main.go to use qstreams terraform-provider-sendgrid instead of the original opteemister.

It fixes the formatting.

It removes the unnecessary &schema.Schema for fields

Sets the api-key back to Required